### PR TITLE
Improve table cell formatting

### DIFF
--- a/cleanslate.css
+++ b/cleanslate.css
@@ -123,13 +123,13 @@
 }
 .cleanslate th, .cleanslate td {
     display: table-cell !important;
-	  vertical-align: middle !important;
+    vertical-align: middle !important;
 }
 .cleanslate td[valign=top] {
-	vertical-align: top !important
+    vertical-align: top !important
 }
 .cleanslate td[valign=bottom] {
-	vertical-align: bottom !important
+    vertical-align: bottom !important
 }
 /* == SPECIFIC ELEMENTS == */
 /* Some of these are browser defaults; some are just useful resets */


### PR DESCRIPTION
This overrides the `baseline` setting for TDs and THs according to convention and also adds bold table heading (verified to be used on Chrome and Firefox).
