### PR TITLE
<pre> should default to white-space:pre

### DIFF
--- a/cleanslate.css
+++ b/cleanslate.css
@@ -447,3 +447,7 @@
     text-decoration:none !important;
     list-style-type:disc !important;
 }
+
+.cleanslate pre {
+    white-space:pre !important;
+}

--- a/cleanslate.css
+++ b/cleanslate.css
@@ -257,7 +257,7 @@
 .cleanslate em {
     font-style:italic !important;
 }
-.cleanslate kbd, .cleanslate samp, .cleanslate code {
+.cleanslate kbd, .cleanslate samp, .cleanslate code, .cleanslate pre {
   font-family:monospace !important;
 }
 .cleanslate a {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre:

The HTML Preformatted Text (&lt;pre&gt;) represents preformatted text. Text within this element is typically displayed in a non-proportional font exactly as it is laid out in the file. Whitespaces inside this element are displayed as typed.