### PR TITLE
Hiding all before and after styles

### DIFF
--- a/cleanslate.css
+++ b/cleanslate.css
@@ -432,6 +432,9 @@
     vertical-align: top !important;
 }
 
+.cleanslate *:before { display: none !important; }
+.cleanslate *:after { display: none !important; }
+
 /* == ROOT CONTAINER ELEMENT == */
 /* This contains default values for child elements to inherit  */
 .cleanslate {


### PR DESCRIPTION
Found that some before and after styles were not being reset, e.g., li:before or li:after, so, I've added two directives which should hide all before and after styles.
