### PR TITLE
adding default box-sizing value

### DIFF
--- a/cleanslate.css
+++ b/cleanslate.css
@@ -81,6 +81,7 @@
     width:auto !important;
     word-spacing:normal !important;
     z-index:auto !important;
+    box-sizing: content-box !important; /* Initial and default value in CSS standard */
 
     /* CSS3 */
     /* Including all prefixes according to http://caniuse.com/ */


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing

> content-box {...} This is the initial and default value as specified by the CSS standard.

Useful since some bootstrap versions use this a lot.